### PR TITLE
feat: Update pricing page with weekly, yearly, and trial plans

### DIFF
--- a/MANUAL_TESTING_CHECKLIST.md
+++ b/MANUAL_TESTING_CHECKLIST.md
@@ -1,0 +1,84 @@
+# Manual Testing Checklist for app/pricing.tsx
+
+This checklist is to manually verify the functionality and appearance of the updated pricing page.
+
+## A. Prerequisites
+1.  **Build and run the application** on a device or simulator.
+2.  **Navigate to the Pricing Page.**
+3.  Open developer tools to monitor console logs and analytics events if possible.
+
+## B. Initial State Verification
+*   [ ] **Page Title:** Is the title "Choose Your Plan"?
+*   [ ] **Default Selected Plan:** Is the Monthly plan ($20/month) selected by default?
+    *   [ ] Does it appear elevated (e.g., stronger shadow, border) compared to other cards?
+    *   [ ] Does it show the "✓ Selected" indicator?
+*   [ ] **Monthly Plan Badge:** Does the Monthly plan correctly display the "Most Popular" badge (purple background, white text) in the top-right corner?
+*   [ ] **CTA Button Text:** Is the main call-to-action button text "Try Free Now"?
+*   [ ] **CTA Subtext (Monthly Plan Trial):** Does the subtext "1 week free trial, then $20/month" appear below the "Try Free Now" button?
+
+## C. Weekly Plan Card Verification
+*   [ ] **Display:** Is the Weekly plan card visible with the correct name ("Weekly Plan"), price ("$4.99/week"), and subtext ("Billed weekly. Cancel anytime.")?
+*   [ ] **Features:** Are the features listed correctly for the Weekly plan?
+*   [ ] **Badge:** Does it correctly have NO badge?
+*   [ ] **Selection Indicator:** Does it show "Select" (or similar unselected state indicator, gray text)?
+
+## D. Yearly Plan Card Verification
+*   [ ] **Display:** Is the Yearly plan card visible with the correct name ("Yearly Plan"), price ("$149.99/year"), and subtext ("SAVE 38%")?
+*   [ ] **Features:** Are the features listed correctly for the Yearly plan (should be same as Monthly)?
+*   [ ] **Badge:** Does it correctly display the "SAVE 38%" badge (green background, white text) in the top-right corner?
+*   [ ] **Selection Indicator:** Does it show "Select" (or similar unselected state indicator, gray text)?
+
+## E. Plan Selection Behavior & Dynamic UI Changes
+*   [ ] **Select Weekly Plan:**
+    *   [ ] Tap the Weekly plan card. Does it become selected (elevated, "✓ Selected" indicator with brand color)?
+    *   [ ] Does the Monthly plan become unselected (no elevation, "Select" indicator)?
+    *   [ ] Does the CTA subtext ("1 week free trial...") disappear?
+*   [ ] **Select Yearly Plan:**
+    *   [ ] Tap the Yearly plan card. Does it become selected (elevated, "✓ Selected" indicator)?
+    *   [ ] Does the Weekly plan (previously selected) become unselected?
+    *   [ ] Does the CTA subtext ("1 week free trial...") remain hidden?
+*   [ ] **Reselect Monthly Plan:**
+    *   [ ] Tap the Monthly plan card. Does it become selected again (elevated, "✓ Selected" indicator)?
+    *   [ ] Does the Yearly plan (previously selected) become unselected?
+    *   [ ] Does the CTA subtext ("1 week free trial...") reappear?
+
+## F. Styling, Layout, and Visuals
+*   [ ] **Card Appearance:** Do all cards have consistent styling (padding, rounded corners, background color)?
+*   [ ] **Selected Card Style:** Is the selected card clearly differentiated (e.g., border color `#8B5CF6`, increased elevation/shadow)?
+*   [ ] **Badge Appearance & Positioning:**
+    *   [ ] Are badges styled correctly (background colors: purple for "Most Popular", green for "SAVE 38%"; white text; padding; border radius)?
+    *   [ ] Are badges positioned correctly in the top-right area of their respective cards?
+*   [ ] **Text Elements:**
+    *   [ ] **Plan Names:** Are they clear and consistently styled (`fontSize: 22`, `fontWeight: '600'`)?
+    *   [ ] **Prices & Suffixes:** Are prices prominent (`fontSize: 40`, bold) and suffixes clear (`fontSize: 18`)?
+    *   [ ] **Subtexts:** Are they styled consistently and legibly (`fontSize: 14`)?
+    *   [ ] **Feature Lists:** Is the styling of feature items consistent?
+*   [ ] **Selection Indicators:** Is the text ("✓ Selected" vs "Select") clear and styled as expected (brand color and bold when selected, gray when not)?
+*   [ ] **Spacing:**
+    *   [ ] Is there adequate and consistent vertical `marginBottom` (24px) between the plan cards?
+    *   [ ] Is spacing within cards (around text, features, price) appropriate?
+*   [ ] **Responsiveness (if possible to test):**
+    *   [ ] If tested on different screen sizes or orientations, do the cards stack correctly and remain readable (cards should be `width: '100%'` up to `maxWidth: 400`)?
+
+## G. "Try Free Now" Button Interaction (Visual/State Check)
+*(Actual checkout flow depends on backend Stripe setup and API responses, focus on UI changes)*
+*   [ ] **With Monthly Plan Selected:**
+    *   [ ] Click "Try Free Now". Does the button text change to "Processing..." temporarily?
+*   [ ] **With Weekly Plan Selected:**
+    *   [ ] Click "Try Free Now". Does the button text also change to "Processing..." temporarily?
+*   [ ] **With Yearly Plan Selected:**
+    *   [ ] Click "Try Free Now". Does the button text also change to "Processing..." temporarily?
+*   [ ] **Error Message Display:** If an error occurs during `initiateStripeCheckout` (e.g., Stripe not initialized, API error), is the `errorMessage` state updated and displayed correctly in `styles.errorText`?
+
+## H. Analytics Event Logging (Developer Tool Check)
+*   [ ] **View Pricing Page:** When the page initially loads, is an analytics event for `VIEW_PRICING_PAGE` logged?
+*   [ ] **Initiate Upgrade (per plan):**
+    *   [ ] With Monthly plan selected, click "Try Free Now". Is an `INITIATE_UPGRADE` event logged with parameters like `{ plan: 'monthly' }`?
+    *   [ ] With Weekly plan selected, click "Try Free Now". Is an `INITIATE_UPGRADE` event logged with parameters like `{ plan: 'weekly' }`?
+    *   [ ] With Yearly plan selected, click "Try Free Now". Is an `INITIATE_UPGRADE` event logged with parameters like `{ plan: 'yearly' }`?
+*   [ ] **Upgrade Failure (if mockable):** If an upgrade fails, is an `UPGRADE_FAILURE` event logged with the correct plan ID and error message?
+
+## I. Developer Console Verification
+*   [ ] **Stripe Placeholder Warning:** When the component mounts, is the following `console.warn` message visible in the developer console: `"TODO: Replace placeholder Stripe Price IDs ('price_weekly_placeholder', 'price_yearly_placeholder') in pricingPlansData with actual Price IDs from your Stripe dashboard."`?
+
+This checklist should help ensure all implemented features and changes on the pricing page are working as expected.

--- a/app/pricing.tsx
+++ b/app/pricing.tsx
@@ -227,8 +227,8 @@ export default function PricingPage() {
           <Text style={styles.planSubtext}>{plan.subtext}</Text>
 
           <View style={styles.featureList}>
-            {plan.features.map((feature, idx) => (
-              <View key={idx} style={styles.featureItem}>
+            {plan.features.map((feature) => (
+              <View key={feature.name} style={styles.featureItem}>
                 <Text style={styles.featureText}>• {feature.name}</Text>
               </View>
             ))}


### PR DESCRIPTION
Updates the pricing page in `app/pricing.tsx` to support three distinct subscription plans: Weekly, Monthly, and Yearly.

Key changes include:

-   **Plan Data:** Introduced a structured `pricingPlansData` array to define plan attributes (name, price, features, Stripe Price ID, badges).
-   **Dynamic UI:** The page now dynamically renders cards for each plan, replacing the previous static display.
-   **State Management:** Implemented `selectedPlan` state to manage your selection, with the Monthly plan as the default.
-   **Plan Cards:**
    -   **Weekly Plan:** $4.99/week, "Billed weekly. Cancel anytime."
    -   **Monthly Plan:** $20/month, "Billed monthly. Cancel anytime." Marked with a "Most Popular" badge and visually elevated by default.
    -   **Yearly Plan:** $149.99/year, with a "SAVE 38%" badge and subtext.
-   **Selection UI:** Plan cards are selectable, with visual feedback (elevation, textual indicator like "✓ Selected") to denote the active choice.
-   **Call-to-Action Button:**
    -   Button text changed to "Try Free Now".
    -   A subtext "1 week free trial, then $20/month" is conditionally displayed when the Monthly plan is selected.
-   **Stripe Integration:** The `initiateStripeCheckout` function now dynamically uses the `priceId` of the `selectedPlan`. Placeholder Price IDs (`price_weekly_placeholder`, `price_yearly_placeholder`) have been used for the new plans, with a console warning for developers to replace them.
-   **Analytics:** Analytics events for initiating upgrades now include the ID of the selected plan.
-   **Styling:** Added and updated styles in the StyleSheet for new elements including badges, selected/unselected card states, and various text components to match the design requirements.

A manual testing checklist (MANUAL_TESTING_CHECKLIST.md) has been prepared to guide full verification of these changes.