### PR TITLE
feat: Implement post-dose feedback screen

### DIFF
--- a/app/post-dose-feedback.tsx
+++ b/app/post-dose-feedback.tsx
@@ -1,0 +1,5 @@
+import PostDoseFeedbackScreen from '../components/PostDoseFeedbackScreen';
+
+export default function PostDoseFeedbackRoute() {
+  return <PostDoseFeedbackScreen />;
+}

--- a/components/PostDoseFeedbackScreen.tsx
+++ b/components/PostDoseFeedbackScreen.tsx
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, TextInput, StyleSheet, SafeAreaView, Alert } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
+import { addUserFeedback } from '../lib/firebase'; // Corrected path
+import { useRouter } from 'expo-router';
+import { FeedbackEntry } from '../types/feedback'; // For type casting selectedOption
+
+const PostDoseFeedbackScreen = () => {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [selectedOption, setSelectedOption] = useState<FeedbackEntry['feeling'] | null>(null);
+  const [logText, setLogText] = useState('');
+  const [showTextInput, setShowTextInput] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleOptionPress = (option: FeedbackEntry['feeling']) => {
+    setSelectedOption(option);
+    if (option === "Something felt wrong") {
+      setShowTextInput(true);
+    } else {
+      setShowTextInput(false);
+      setLogText(''); // Clear log text if other options are selected
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedOption) {
+      Alert.alert("Selection Required", "Please select how the dose felt.");
+      return;
+    }
+
+    if (!user?.uid) {
+      Alert.alert("Error", "User not identified. Please try logging in again.");
+      console.error("User ID is not available for feedback submission.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const feedbackData: Omit<FeedbackEntry, 'timestamp' | 'userId'> = {
+      feeling: selectedOption,
+    };
+
+    if (selectedOption === "Something felt wrong" && logText.trim()) {
+      feedbackData.log = logText.trim();
+    }
+
+    const success = await addUserFeedback(feedbackData, user.uid);
+
+    if (success) {
+      Alert.alert("Feedback Submitted", "Thank you for your feedback!");
+      router.replace('/(tabs)/new-dose'); // Navigate to home/new-dose tab
+    } else {
+      Alert.alert("Submission Failed", "Could not submit feedback. Please try again.");
+    }
+
+    setIsSubmitting(false);
+  };
+
+  // Log user ID when component mounts or user changes, for verification (can be removed in production)
+  React.useEffect(() => {
+    console.log('User ID from useEffect:', user?.uid);
+  }, [user]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>How did this dose feel?</Text>
+
+      <TouchableOpacity
+        style={[styles.button, selectedOption === "Great" && styles.selectedButton]}
+        onPress={() => handleOptionPress("Great")}
+        disabled={isSubmitting}
+      >
+        <Text style={styles.buttonText}>Great</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[styles.button, selectedOption === "Mild side effects" && styles.selectedButton]}
+        onPress={() => handleOptionPress("Mild side effects")}
+        disabled={isSubmitting}
+      >
+        <Text style={styles.buttonText}>Mild side effects</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[styles.button, selectedOption === "Something felt wrong" && styles.selectedButton]}
+        onPress={() => handleOptionPress("Something felt wrong")}
+        disabled={isSubmitting}
+      >
+        <Text style={styles.buttonText}>Something felt wrong</Text>
+      </TouchableOpacity>
+
+      {showTextInput && (
+        <TextInput
+          style={styles.textInput}
+          placeholder="Optional: Describe what felt wrong..."
+          placeholderTextColor="#888"
+          value={logText}
+          onChangeText={setLogText}
+          editable={!isSubmitting}
+        />
+      )}
+
+      <TouchableOpacity
+        style={[styles.submitButton, isSubmitting && styles.submitButtonDisabled]}
+        onPress={handleSubmit}
+        disabled={isSubmitting}
+      >
+        <Text style={styles.submitButtonText}>{isSubmitting ? 'Submitting...' : 'Submit'}</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center', // Keep centered, adjust padding for space
+    paddingHorizontal: 20,
+    paddingVertical: 30, // Increased vertical padding
+    backgroundColor: '#f7f7f7', // Slightly lighter background
+  },
+  title: {
+    fontSize: 28, // Increased font size
+    fontWeight: '600', // Slightly less bold than 'bold'
+    color: '#333',
+    marginBottom: 40, // Increased margin
+    textAlign: 'center',
+  },
+  button: {
+    backgroundColor: '#ffffff',
+    paddingVertical: 18, // Increased padding
+    paddingHorizontal: 25,
+    borderRadius: 30, // More rounded
+    marginBottom: 20, // Increased margin
+    width: '90%', // Wider buttons
+    alignItems: 'center',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 1 }, // Subtle shadow
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+    elevation: 2, // Subtle elevation for Android
+    borderWidth: 1,
+    borderColor: '#e0e0e0', // Light border for all buttons
+  },
+  selectedButton: {
+    backgroundColor: '#e6f2ff', // Lighter blue for selected
+    borderColor: '#007bff', // Primary color border
+    borderWidth: 2, // Thicker border for selected
+  },
+  buttonText: {
+    fontSize: 18,
+    color: '#2c3e50', // Darker, more saturated text color
+    fontWeight: '500',
+  },
+  textInput: {
+    width: '90%', // Match button width
+    height: 120, // Increased height for more text
+    borderColor: '#bdc3c7', // Softer border color
+    borderWidth: 1,
+    borderRadius: 12, // More rounded corners
+    padding: 15,
+    marginTop: 15, // Add margin top
+    marginBottom: 25, // Increased margin
+    backgroundColor: '#ffffff',
+    textAlignVertical: 'top',
+    fontSize: 16,
+    color: '#333',
+  },
+  submitButton: {
+    backgroundColor: '#007bff', // Primary action color
+    paddingVertical: 18, // Increased padding
+    paddingHorizontal: 30,
+    borderRadius: 30, // Match option buttons
+    width: '90%', // Match other elements
+    alignItems: 'center',
+    marginTop: 25, // Increased margin
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 5,
+    elevation: 4,
+  },
+  submitButtonDisabled: {
+    backgroundColor: '#a0cfff',
+    opacity: 0.7, // Make it look more disabled
+  },
+  submitButtonText: {
+    fontSize: 19, // Slightly larger text for submit
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+});
+
+export default PostDoseFeedbackScreen;

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,8 +1,9 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getAnalytics } from "firebase/analytics";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, collection, addDoc } from "firebase/firestore";
 import Constants from "expo-constants";
+import { FeedbackEntry } from '../types/feedback';
 
 // Firebase configuration from app.config.js
 const firebaseConfig = Constants.expoConfig?.extra?.firebase || {
@@ -24,3 +25,31 @@ export const db = getFirestore(app);
 export const analytics = typeof window !== "undefined"
   ? getAnalytics(app)
   : undefined;
+
+/**
+ * Adds a user's feedback to Firestore.
+ * @param feedbackData - The feedback data, excluding userId and timestamp.
+ * @param userId - The ID of the user submitting the feedback.
+ * @returns True if successful, false otherwise.
+ */
+export const addUserFeedback = async (
+  feedbackData: Omit<FeedbackEntry, 'timestamp' | 'userId'>,
+  userId: string
+): Promise<boolean> => {
+  try {
+    const timestamp = new Date();
+    const feedbackEntry: FeedbackEntry = {
+      ...feedbackData,
+      userId,
+      timestamp,
+    };
+
+    const feedbackCollectionRef = collection(db, 'userFeedback');
+    await addDoc(feedbackCollectionRef, feedbackEntry);
+    console.log("Feedback added successfully with ID: ", feedbackEntry.userId, feedbackEntry.timestamp);
+    return true;
+  } catch (error) {
+    console.error("Error adding feedback: ", error);
+    return false;
+  }
+};

--- a/lib/hooks/useDoseCalculator.ts
+++ b/lib/hooks/useDoseCalculator.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { useRouter } from 'expo-router';
 import { validateUnitCompatibility, getCompatibleConcentrationUnits } from '../doseUtils';
 
 type ScreenStep = 'intro' | 'scan' | 'manualEntry';
@@ -17,6 +18,7 @@ const isValidValue = (value: any): boolean => {
 };
 
 export default function useDoseCalculator({ checkUsageLimit }: UseDoseCalculatorProps) {
+  const router = useRouter();
   const isInitialized = useRef(false);
   const lastActionTimestamp = useRef(Date.now());
 
@@ -377,14 +379,17 @@ export default function useDoseCalculator({ checkUsageLimit }: UseDoseCalculator
       // Previously only navigated if there was no error or a recommendedMarking was available
       setManualStep('finalResult');
       console.log('[useDoseCalculator] Set manualStep to finalResult');
+      router.push('/post-dose-feedback');
     } catch (error) {
       console.error('[useDoseCalculator] Error in handleCalculateFinal:', error);
       setCalculationError('Error calculating dose. Please check your inputs and try again.');
       // Ensure we still navigate to the results screen even if there's an error
       setManualStep('finalResult');
       console.log('[useDoseCalculator] Set manualStep to finalResult (after error)');
+      // Consider if navigation to feedback should also happen in catch block
+      // For now, only navigating on successful calculation path, even if result is an error message
     }
-  }, [doseValue, concentration, manualSyringe, unit, totalAmount, concentrationUnit, solutionVolume, medicationInputType]);
+  }, [doseValue, concentration, manualSyringe, unit, totalAmount, concentrationUnit, solutionVolume, medicationInputType, router]);
 
   const handleBack = useCallback(() => {
     try {

--- a/types/feedback.ts
+++ b/types/feedback.ts
@@ -1,0 +1,6 @@
+export interface FeedbackEntry {
+  userId: string;
+  feeling: "Great" | "Mild side effects" | "Something felt wrong";
+  log?: string; // Optional, for the text input when "Something felt wrong" is selected
+  timestamp: Date;
+}


### PR DESCRIPTION
Adds a new screen allowing you to provide feedback on how a dose felt.

Key changes:
- Created `PostDoseFeedbackScreen.tsx` with options: "Great", "Mild side effects", "Something felt wrong".
- Includes an optional text input if "Something felt wrong" is selected.
- Feedback (selected option, optional log, userId, timestamp) is stored in a new `userFeedback` collection in Firestore.
- You are navigated to this screen after dose confirmation on the `new-dose` tab.
- After submitting feedback, you are navigated back to the `new-dose` screen.
- Added `FeedbackEntry` type for data consistency.
- Implemented `addUserFeedback` function in `lib/firebase.ts` for saving data.
- Basic styling and UX improvements for the new screen.