### PR TITLE
Fix: Improve sign-out button feedback and reliability

### DIFF
--- a/components/IntroScreen.tsx
+++ b/components/IntroScreen.tsx
@@ -180,7 +180,6 @@ export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatin
   }, [router]);
 
   const handleLogoutPress = useCallback(async () => {
-    console.log('[IntroScreen] handleLogoutPress CALLED!');
     console.log('[IntroScreen] Logout button pressed');
     setIsProfileMenuOpen(false);
     try {

--- a/components/IntroScreen.tsx
+++ b/components/IntroScreen.tsx
@@ -21,7 +21,7 @@ interface IntroScreenProps {
 export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatingFromIntro }: IntroScreenProps) {
   console.log('[IntroScreen] ========== INTRO SCREEN RENDER ==========');
   
-  const { user, auth, logout } = useAuth();
+  const { user, auth, logout, isSigningOut } = useAuth();
   const { disclaimerText, profile, isLoading } = useUserProfile();
   const { usageData } = useUsageTracking();
   const router = useRouter();
@@ -180,6 +180,7 @@ export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatin
   }, [router]);
 
   const handleLogoutPress = useCallback(async () => {
+    console.log('[IntroScreen] handleLogoutPress CALLED!');
     console.log('[IntroScreen] Logout button pressed');
     setIsProfileMenuOpen(false);
     try {
@@ -248,9 +249,18 @@ export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatin
         )}
         
         {/* Show loading state if profile is still loading */}
-        {isLoading && (
+        {isLoading && !isSigningOut && (
           <View style={styles.loadingContainer}>
             <Text style={styles.loadingText}>Loading your profile...</Text>
+          </View>
+        )}
+
+        {/* Show signing out message */}
+        {isSigningOut && (
+          <View style={styles.signingOutContainer}>
+            <Text style={styles.signingOutText}>
+              Signed out successfully. You will be signed in anonymously shortly.
+            </Text>
           </View>
         )}
         
@@ -263,8 +273,8 @@ export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatin
           />
         )}
         
-        {/* Main content section - only show when not loading */}
-        {!isLoading && (
+        {/* Main content section - only show when not loading and not signing out */}
+        {!isLoading && !isSigningOut && (
           <View style={styles.content}>
             {/* App icon and welcome message */}
             <View style={styles.welcomeContainer}>
@@ -310,8 +320,8 @@ export default function IntroScreen({ setScreenStep, resetFullForm, setNavigatin
           </View>
         )}
         
-        {/* Bottom section with usage info, authentication and upgrade options - only show when not loading */}
-        {!isLoading && (
+        {/* Bottom section with usage info, authentication and upgrade options - only show when not loading and not signing out */}
+        {!isLoading && !isSigningOut && (
           <View style={styles.bottomSection}>
             {/* Usage Status Card - shows scans remaining and upgrade options together */}
             <View style={styles.usageStatusCard}>
@@ -451,6 +461,20 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#666',
     textAlign: 'center',
+  },
+  // Signing out state
+  signingOutContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: 'rgba(0,0,0,0.05)', // Slight overlay to indicate change
+  },
+  signingOutText: {
+    fontSize: 16,
+    color: '#333', // Darker text for better readability
+    textAlign: 'center',
+    paddingHorizontal: 30, // Ensure text doesn't touch edges
   },
   // Invisible overlay to capture taps outside the menu
   menuOverlay: {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   user: User | null;
   auth: Auth;
   logout: () => Promise<void>;
+  isSigningOut: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -84,7 +85,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, auth, logout }}>
+    <AuthContext.Provider value={{ user, auth, logout, isSigningOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
       // Disable type checking during transformation for speed,
       // type checking was done in a previous step anyway.
       isolatedModules: true,
+      babelConfig: true, // Tell ts-jest to use babel.config.js
     }],
   },
   moduleNameMapper: {


### PR DESCRIPTION
The sign-out button on the IntroScreen previously did not provide clear visual feedback to you during the sign-out process. This commit addresses the issue by:

1.  Exposing `isSigningOut` state from `AuthContext`:
    - Modified `AuthContextType` and the provider's value in `contexts/AuthContext.tsx` to include `isSigningOut`.

2.  Implementing UI feedback in `IntroScreen.tsx`:
    - The `IntroScreen` now consumes the `isSigningOut` state from `useAuth()`.
    - When `isSigningOut` is true, a message ("Signed out successfully. You will be signed in anonymously shortly.") is displayed, and other non-relevant UI elements are hidden. This provides clear feedback to you, consistent with the behavior described in `MANUAL_TESTING_SIGN_OUT.md`.

3.  Ensured `handleLogoutPress` is triggered:
    - Added a `console.log` to confirm the function call (this can be removed later if desired, but was useful for debugging).

Additionally, a Jest configuration issue (`babelConfig: true` for `ts-jest`) was resolved, allowing more tests to pass, although a specific environment issue with `Appearance.getColorScheme` in `AuthContext.test.tsx` remains an open point for future investigation.