### PR TITLE
Add CANCEL_SUBSCRIPTION analytics event

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../lib/analytics';
+
+export default function SettingsScreen() {
+  const handleCancelSubscription = () => {
+    // TODO: Add real cancellation or downgrade logic
+    logAnalyticsEvent(ANALYTICS_EVENTS.CANCEL_SUBSCRIPTION);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Settings</Text>
+      <TouchableOpacity style={styles.button} onPress={handleCancelSubscription}>
+        <Text style={styles.buttonText}>Cancel Subscription</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5F5F5',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    marginBottom: 20,
+  },
+  button: {
+    backgroundColor: '#FF3B30',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});

--- a/docs/analytics-implementation.md
+++ b/docs/analytics-implementation.md
@@ -22,6 +22,8 @@ The following custom events are tracked:
 - **initiate_upgrade**: Logged when user starts upgrade process
 - **upgrade_success**: Logged on successful plan upgrade
 - **upgrade_failure**: Logged on upgrade failure with error details
+- **cancel_subscription**: Logged when a user cancels their plan
+- **downgrade_plan**: Logged when a user downgrades to a lower tier
 
 ### Scan Usage Events
 - **scan_attempt**: Logged when user attempts a scan

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -12,6 +12,8 @@ export const ANALYTICS_EVENTS = {
   INITIATE_UPGRADE: 'initiate_upgrade',
   UPGRADE_SUCCESS: 'upgrade_success',
   UPGRADE_FAILURE: 'upgrade_failure',
+  CANCEL_SUBSCRIPTION: 'cancel_subscription',
+  DOWNGRADE_PLAN: 'downgrade_plan',
   SCAN_ATTEMPT: 'scan_attempt',
   SCAN_SUCCESS: 'scan_success',
   SCAN_FAILURE: 'scan_failure',


### PR DESCRIPTION
## Summary
- track subscription cancellation events in `ANALYTICS_EVENTS`
- document `cancel_subscription` and `downgrade_plan` in analytics docs
- provide a placeholder settings screen that logs the cancel event

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_683fc57f9028832daac682070d04b422