### PR TITLE
Add limit modal view analytics event

### DIFF
--- a/components/LimitModal.tsx
+++ b/components/LimitModal.tsx
@@ -15,6 +15,12 @@ export default function LimitModal({ visible, isAnonymous, isPremium = false, on
 
   console.log('[LimitModal] Rendering', { visible, isAnonymous, isPremium });
 
+  React.useEffect(() => {
+    if (visible) {
+      logAnalyticsEvent(ANALYTICS_EVENTS.LIMIT_MODAL_VIEW);
+    }
+  }, [visible]);
+
   const handleSignIn = () => {
     console.log('[LimitModal] Sign In button pressed');
     logAnalyticsEvent(ANALYTICS_EVENTS.LIMIT_MODAL_ACTION, { action: 'sign_in' });

--- a/docs/analytics-implementation.md
+++ b/docs/analytics-implementation.md
@@ -30,6 +30,7 @@ The following custom events are tracked:
 - **reach_scan_limit**: Logged when user hits scan limit
 
 ### User Interaction Events
+- **limit_modal_view**: Logged when the limit modal is displayed
 - **limit_modal_action**: Logged for limit modal interactions (sign_in, upgrade, cancel)
 - **error_occurred**: Logged for critical errors with type and message
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -16,6 +16,7 @@ export const ANALYTICS_EVENTS = {
   SCAN_SUCCESS: 'scan_success',
   SCAN_FAILURE: 'scan_failure',
   REACH_SCAN_LIMIT: 'reach_scan_limit',
+  LIMIT_MODAL_VIEW: 'limit_modal_view',
   LIMIT_MODAL_ACTION: 'limit_modal_action',
   ERROR_OCCURRED: 'error_occurred',
   // Onboarding events


### PR DESCRIPTION
## Summary
- track when the usage limit modal is opened
- document the new `limit_modal_view` analytics event
- log `LIMIT_MODAL_VIEW` in LimitModal when it becomes visible

## Testing
- `npx jest` *(fails: 403 Forbidden to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_683fc5736058832d89660853a545b63b