### PR TITLE
Add manual entry analytics events

### DIFF
--- a/components/ManualEntryScreen.tsx
+++ b/components/ManualEntryScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { ArrowRight } from 'lucide-react-native';
 import { isMobileWeb } from '../lib/utils';
@@ -11,6 +11,7 @@ import ReconstitutionStep from '../components/ReconstitutionStep';
 import SyringeStep from '../components/SyringeStep';
 import PreDoseConfirmationStep from '../components/PreDoseConfirmationStep';
 import FinalResultDisplay from '../components/FinalResultDisplay';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../lib/analytics';
 
 interface ManualEntryScreenProps {
   manualStep: 'dose' | 'medicationSource' | 'concentrationInput' | 'totalAmountInput' | 'reconstitution' | 'syringe' | 'preDoseConfirmation' | 'finalResult';
@@ -109,6 +110,9 @@ export default function ManualEntryScreen({
   validateDoseInput,
   validateConcentrationInput,
 }: ManualEntryScreenProps) {
+  useEffect(() => {
+    logAnalyticsEvent(ANALYTICS_EVENTS.MANUAL_ENTRY_STARTED);
+  }, []);
   // Validation functions for each step
   const isDoseStepValid = (): boolean => {
     return Boolean(dose && !isNaN(parseFloat(dose)));

--- a/docs/analytics-implementation.md
+++ b/docs/analytics-implementation.md
@@ -29,6 +29,10 @@ The following custom events are tracked:
 - **scan_failure**: Logged on scan failure with reason
 - **reach_scan_limit**: Logged when user hits scan limit
 
+### Manual Entry Events
+- **manual_entry_started**: Logged when the manual entry screen is opened
+- **manual_entry_completed**: Logged when the user finishes the manual entry process
+
 ### User Interaction Events
 - **limit_modal_action**: Logged for limit modal interactions (sign_in, upgrade, cancel)
 - **error_occurred**: Logged for critical errors with type and message

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -23,6 +23,9 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_STEP_COMPLETE: 'onboarding_step_complete',
   ONBOARDING_STEP_SKIP: 'onboarding_step_skip',
   ONBOARDING_COMPLETE: 'onboarding_complete',
+  // Manual entry events
+  MANUAL_ENTRY_STARTED: 'manual_entry_started',
+  MANUAL_ENTRY_COMPLETED: 'manual_entry_completed',
 } as const;
 
 // User property names

--- a/lib/hooks/useDoseCalculator.ts
+++ b/lib/hooks/useDoseCalculator.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { validateUnitCompatibility, getCompatibleConcentrationUnits } from '../doseUtils';
 import { FeedbackContextType } from '../../types/feedback';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../analytics';
 
 type ScreenStep = 'intro' | 'scan' | 'manualEntry' | 'postDoseFeedback';
 type ManualStep = 'dose' | 'medicationSource' | 'concentrationInput' | 'totalAmountInput' | 'reconstitution' | 'syringe' | 'preDoseConfirmation' | 'finalResult';
@@ -403,9 +404,10 @@ export default function useDoseCalculator({ checkUsageLimit }: UseDoseCalculator
     }
   }, [doseValue, concentration, manualSyringe, unit, totalAmount, concentrationUnit, solutionVolume, medicationInputType]);
 
-  const handleNextPreDoseConfirmation = useCallback(() => {
+const handleNextPreDoseConfirmation = useCallback(() => {
     try {
       console.log('[useDoseCalculator] handleNextPreDoseConfirmation called');
+      logAnalyticsEvent(ANALYTICS_EVENTS.MANUAL_ENTRY_COMPLETED);
       setManualStep('finalResult');
       console.log('[useDoseCalculator] Set manualStep to finalResult');
       lastActionTimestamp.current = Date.now();


### PR DESCRIPTION
## Summary
- add MANUAL_ENTRY events
- document new events in analytics guide
- log MANUAL_ENTRY_STARTED when manual entry screen mounts
- log MANUAL_ENTRY_COMPLETED when manual process finishes

## Testing
- `npx jest` *(fails: 403 Forbidden on npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_683fc5760144832d9b1db17127059a1f