### PR TITLE
Add feedback analytics events

### DIFF
--- a/components/PostDoseFeedbackScreen.tsx
+++ b/components/PostDoseFeedbackScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { View, Text, TouchableOpacity, TextInput, ScrollView, StyleSheet } from 'react-native';
 import { ChevronRight, X, CheckCircle } from 'lucide-react-native';
 import { FeedbackType, FeedbackContextType } from '../types/feedback';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../lib/analytics';
 
 interface PostDoseFeedbackScreenProps {
   context: FeedbackContextType;
@@ -32,9 +33,17 @@ export default function PostDoseFeedbackScreen({
 
   const handleSubmit = useCallback(() => {
     if (selectedFeedback) {
+      logAnalyticsEvent(ANALYTICS_EVENTS.FEEDBACK_SUBMITTED, {
+        feedbackType: selectedFeedback,
+      });
       onSubmit(selectedFeedback, notes.trim() || undefined);
     }
   }, [selectedFeedback, notes, onSubmit]);
+
+  const handleSkip = useCallback(() => {
+    logAnalyticsEvent(ANALYTICS_EVENTS.FEEDBACK_SKIPPED);
+    onSkip();
+  }, [onSkip]);
 
   const getFeedbackEmoji = (type: FeedbackType) => {
     switch (type) {
@@ -120,7 +129,7 @@ export default function PostDoseFeedbackScreen({
       <View style={styles.buttonsContainer}>
         <TouchableOpacity
           style={[styles.skipButton, isMobileWeb && styles.skipButtonMobile]}
-          onPress={onSkip}
+          onPress={handleSkip}
         >
           <X color="#6b7280" size={18} style={{ marginRight: 8 }} />
           <Text style={styles.skipButtonText}>Skip & continue to {nextActionText}</Text>

--- a/docs/analytics-implementation.md
+++ b/docs/analytics-implementation.md
@@ -33,6 +33,10 @@ The following custom events are tracked:
 - **limit_modal_action**: Logged for limit modal interactions (sign_in, upgrade, cancel)
 - **error_occurred**: Logged for critical errors with type and message
 
+### Feedback Events
+- **feedback_submitted**: Logged when post-dose feedback is submitted
+- **feedback_skipped**: Logged when the feedback step is skipped
+
 ## User Properties
 
 The following user properties are set and maintained:

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -23,6 +23,8 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_STEP_COMPLETE: 'onboarding_step_complete',
   ONBOARDING_STEP_SKIP: 'onboarding_step_skip',
   ONBOARDING_COMPLETE: 'onboarding_complete',
+  FEEDBACK_SUBMITTED: 'feedback_submitted',
+  FEEDBACK_SKIPPED: 'feedback_skipped',
 } as const;
 
 // User property names


### PR DESCRIPTION
## Summary
- add `FEEDBACK_SUBMITTED` and `FEEDBACK_SKIPPED` constants
- document new feedback events
- log feedback analytics from PostDoseFeedbackScreen

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fc5790684832d8f1c428efdd740f5