### PR TITLE
I've added analytics for the manual entry flow.

### DIFF
--- a/components/ManualEntryScreen.tsx
+++ b/components/ManualEntryScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { ArrowRight } from 'lucide-react-native';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../lib/analytics';
 import { isMobileWeb } from '../lib/utils';
 import CustomProgressBar from '../components/CustomProgressBar';
 import DoseInputStep from '../components/DoseInputStep';
@@ -111,6 +112,10 @@ export default function ManualEntryScreen({
   validateDoseInput,
   validateConcentrationInput,
 }: ManualEntryScreenProps) {
+  useEffect(() => {
+    logAnalyticsEvent(ANALYTICS_EVENTS.MANUAL_ENTRY_STARTED);
+  }, []); // Empty dependency array ensures this runs only on mount
+
   // Validation functions for each step
   const isDoseStepValid = (): boolean => {
     return Boolean(dose && !isNaN(parseFloat(dose)));

--- a/docs/analytics-implementation.md
+++ b/docs/analytics-implementation.md
@@ -31,6 +31,10 @@ The following custom events are tracked:
 - **scan_failure**: Logged on scan failure with reason
 - **reach_scan_limit**: Logged when user hits scan limit
 
+### Manual Entry Events
+- **MANUAL_ENTRY_STARTED**: Logged when the user starts the manual entry flow.
+- **MANUAL_ENTRY_COMPLETED**: Logged when the user completes the manual entry flow and proceeds to the feedback screen.
+
 ### User Interaction Events
 - **limit_modal_view**: Logged when the limit modal is displayed
 - **limit_modal_action**: Logged for limit modal interactions (sign_in, upgrade, cancel)

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -28,6 +28,8 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_COMPLETE: 'onboarding_complete',
   FEEDBACK_SUBMITTED: 'feedback_submitted',
   FEEDBACK_SKIPPED: 'feedback_skipped',
+  MANUAL_ENTRY_STARTED: 'manual_entry_started',
+  MANUAL_ENTRY_COMPLETED: 'manual_entry_completed',
 } as const;
 
 // User property names

--- a/lib/hooks/useDoseCalculator.ts
+++ b/lib/hooks/useDoseCalculator.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { validateUnitCompatibility, getCompatibleConcentrationUnits } from '../doseUtils';
 import { FeedbackContextType } from '../../types/feedback';
+import { logAnalyticsEvent, ANALYTICS_EVENTS } from '../analytics';
 
 type ScreenStep = 'intro' | 'scan' | 'manualEntry' | 'postDoseFeedback';
 type ManualStep = 'dose' | 'medicationSource' | 'concentrationInput' | 'totalAmountInput' | 'reconstitution' | 'syringe' | 'preDoseConfirmation' | 'finalResult';
@@ -487,6 +488,7 @@ export default function useDoseCalculator({ checkUsageLimit }: UseDoseCalculator
   }, [resetFullForm]);
 
   const handleGoToFeedback = useCallback((nextAction: 'new_dose' | 'scan_again' | 'start_over') => {
+    logAnalyticsEvent(ANALYTICS_EVENTS.MANUAL_ENTRY_COMPLETED);
     setFeedbackContext({
       nextAction,
       doseInfo: {


### PR DESCRIPTION
This commit introduces analytics tracking for the manual entry feature.

New events:
- MANUAL_ENTRY_STARTED: Logged when the manual entry screen is first displayed.
- MANUAL_ENTRY_COMPLETED: Logged when you successfully complete the manual entry process and proceed to the next step (feedback screen).

These events have also been documented in the analytics implementation guide.